### PR TITLE
Remove confusing name from example

### DIFF
--- a/docs/classes/queue.html
+++ b/docs/classes/queue.html
@@ -66,9 +66,9 @@ queue.addWorker(<span class="hljs-keyword">new</span> Worker(<span class="hljs-s
      setTimeout(<span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {
          <span class="hljs-built_in">console</span>.log(payload.text);
          resolve();
-     }, payload.timeout);});
+     }, payload.delay);});
 }))
-queue.addJob(<span class="hljs-string">"testWorker"</span>,{text:<span class="hljs-string">"Job example palyoad content text"</span>,timeout:<span class="hljs-number">5000</span>})
+queue.addJob(<span class="hljs-string">"testWorker"</span>,{text:<span class="hljs-string">"Job example palyoad content text"</span>,delay:<span class="hljs-number">5000</span>})
 </code></pre>
 <h2><a class="anchor" aria-hidden="true" id="hierarchy"></a><a href="#hierarchy" aria-hidden="true" class="hash-link"><svg class="hash-link-icon" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>Hierarchy</h2>
 <ul>


### PR DESCRIPTION
The example is a bit confusing because `timeout` is also a key of the `options` parameter.