### PR TITLE
Cannot find buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/jest": "^24.0.17",
     "@types/react": "^16.8.25",
     "@types/react-native": "0.60.3",
-    "buffer": "^5.4.0",
     "jest": "24.8.0",
     "metro-react-native-babel-preset": "^0.56.0",
     "react": "16.8.0",
@@ -62,6 +61,7 @@
     ]
   },
   "dependencies": {
-    "react-native-uuid": "1.4.9"
+    "react-native-uuid": "1.4.9",
+    "buffer": "^5.4.0"
   }
 }

--- a/react-native-job-queue.podspec
+++ b/react-native-job-queue.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.authors      = { "Simon" => "simon_ermler@web.de" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/SimonErm/react-native-job-queue.git", :tag => "#{s.version}" }
+  s.swift_version = "5.0"
 
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true


### PR DESCRIPTION
While confirming that `feature/set_swift_version` worked correctly for issue #2 I ran into an issue with a package that `react-native-uuid` uses. There was a PR to fix it in that package, but that package seems to be unmaintained.

Moving the requirement for `buffer` from `devDependencies` to `dependencies` solved the problem.