### PR TITLE
[FIX] Mark active but timed out jobs as failed

### DIFF
--- a/android/src/main/java/com/github/simonerm/JobDao.java
+++ b/android/src/main/java/com/github/simonerm/JobDao.java
@@ -19,6 +19,9 @@ public interface JobDao {
     @Query("SELECT * FROM job WHERE active == 0 AND failed == '' ORDER BY priority DESC,datetime(created)")
     List<Job> getJobs();
 
+    @Query("SELECT * FROM job WHERE active == 1 AND failed == '' AND timeout != 0 AND datetime(created, ('+' || (timeout/1000) || ' seconds')) < datetime('now')")
+    List<Job> getActiveButTimedOutJobs();
+
     @Query("SELECT * FROM job WHERE active == 0 AND failed == '' AND worker_name == :workerName ORDER BY priority DESC,datetime(created) LIMIT :limit")
     List<Job> getJobsForWorker(String workerName, int limit);
 

--- a/android/src/main/java/com/github/simonerm/JobQueueModule.java
+++ b/android/src/main/java/com/github/simonerm/JobQueueModule.java
@@ -64,6 +64,14 @@ public class JobQueueModule extends ReactContextBaseJavaModule {
         promise.resolve(ConversionHelper.getJobsAsWritableArray(jobs));
     }
 
+    @ReactMethod
+    public void getActiveButTimedOutJobs(Promise promise) {
+        JobDao dao = JobDatabase.getAppDatabase(this.reactContext).jobDao();
+
+        List<Job> jobs=dao.getActiveButTimedOutJobs();
+        promise.resolve(ConversionHelper.getJobsAsWritableArray(jobs));
+    }
+
 
     @ReactMethod
     public void getJobsForWorker(String workerName,int limit,Promise promise){

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -8,6 +8,7 @@ export interface IAppProps {}
 
 export interface IAppState {
     counter: number;
+    fails: number;
 }
 
 export default class App extends React.Component<IAppProps, IAppState> {
@@ -15,6 +16,7 @@ export default class App extends React.Component<IAppProps, IAppState> {
         super(props);
         this.state = {
             counter: 0,
+            fails: 0,
         };
     }
     componentDidMount() {
@@ -28,17 +30,23 @@ export default class App extends React.Component<IAppProps, IAppState> {
                 return new Promise((resolve) => {
                     setTimeout(() => {
                         this.setState({
-                            counter: payload.id
+                            counter: this.state.counter + payload.id
                         })
                         resolve();
                     }, 5000);
                 });
+            }, {
+                onFailure: () => {
+                    this.setState({
+                        fails: this.state.fails + 1,
+                    })
+                }
             })
         );
     }
 
     public render() {
-        const { counter } = this.state;
+        const { counter, fails } = this.state;
         return (
             <View style={styles.container}>
                 <Button
@@ -49,6 +57,19 @@ export default class App extends React.Component<IAppProps, IAppState> {
                 />
                 <View style={styles.spacing}>
                     <Button
+                        title='add job with 4 sec timeout'
+                        onPress={() => {
+                            queue.addJob('testWorker', { id: counter + 1 }, {
+                                timeout: 4000,
+                                priority: 1,
+                                attempts: 2,
+                            }, false);
+                        }}
+                    />
+                </View>
+                <Text style={styles.textCenter}>This job should fail, as the executer takes 5 seconds to execute the job.</Text>
+                <View style={styles.spacing}>
+                    <Button
                         title='start Queue'
                         onPress={() => {
                             queue.start();
@@ -57,6 +78,7 @@ export default class App extends React.Component<IAppProps, IAppState> {
                 </View>
                 <View style={styles.spacing}>
                     <Text>Counter: {counter}</Text>
+                    <Text>Fails: {fails}</Text>
                 </View>
             </View>
         );
@@ -71,5 +93,8 @@ const styles = StyleSheet.create({
     },
     spacing: {
         marginTop: 20,
+    },
+    textCenter: {
+        textAlign: "center",
     }
 });

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
-import { Button, View } from 'react-native';
+import { Button, StyleSheet, Text, View } from 'react-native';
 
 import queue from '../src/Queue';
 import { Worker } from '../src/Worker';
 
 export interface IAppProps {}
 
-export interface IAppState {}
-let counter = 0;
+export interface IAppState {
+    counter: number;
+}
+
 export default class App extends React.Component<IAppProps, IAppState> {
     constructor(props: IAppProps) {
         super(props);
-        this.state = {};
+        this.state = {
+            counter: 0,
+        };
     }
     componentDidMount() {
         queue.configure({
@@ -23,29 +27,49 @@ export default class App extends React.Component<IAppProps, IAppState> {
             new Worker('testWorker', async (payload) => {
                 return new Promise((resolve) => {
                     setTimeout(() => {
-                        console.log(payload);
+                        this.setState({
+                            counter: payload.id
+                        })
                         resolve();
                     }, 5000);
                 });
             })
         );
     }
+
     public render() {
+        const { counter } = this.state;
         return (
-            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <View style={styles.container}>
                 <Button
                     title='add Job'
                     onPress={() => {
-                        queue.addJob('testWorker', { id: counter++ }, undefined, false);
+                        queue.addJob('testWorker', { id: counter + 1 }, undefined, false);
                     }}
                 />
-                <Button
-                    title='start Queue'
-                    onPress={() => {
-                        queue.start();
-                    }}
-                />
+                <View style={styles.spacing}>
+                    <Button
+                        title='start Queue'
+                        onPress={() => {
+                            queue.start();
+                        }}
+                    />
+                </View>
+                <View style={styles.spacing}>
+                    <Text>Counter: {counter}</Text>
+                </View>
             </View>
         );
     }
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+    spacing: {
+        marginTop: 20,
+    }
+});

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -57,7 +57,7 @@ PODS:
     - React-cxxreact (= 0.60.4)
     - React-jsi (= 0.60.4)
   - React-jsinspector (0.60.4)
-  - react-native-job-queue (0.1.0):
+  - react-native-job-queue (0.2.2):
     - React
   - React-RCTActionSheet (0.60.4):
     - React-Core (= 0.60.4)
@@ -175,7 +175,7 @@ SPEC CHECKSUMS:
   React-jsi: 21d3153b1153fbf6510a92b6b11e33e725cb7432
   React-jsiexecutor: 7549641e48bafae7bfee3f3ea19bf4901639c5de
   React-jsinspector: 73f24a02fa684ed6a2b828ba116874a2191ded88
-  react-native-job-queue: f0d7bac7fc4d62fb376c5c862898791065b900a2
+  react-native-job-queue: 12c2e2caa8515d6da93df7bc3f4390e55ff8e8cc
   React-RCTActionSheet: 9f71d7ae3e8fb10e08d162cbf14c621349dbfab3
   React-RCTAnimation: 981d8c95b0e30918a9832ccac32af83562a27fae
   React-RCTBlob: 21e73d1020a302a75fed30dbaee9f15287b80baa

--- a/ios/Job.swift
+++ b/ios/Job.swift
@@ -146,8 +146,8 @@ extension SQLiteDatabase {
         
         return jobs
     }
-    func getJobs() -> [Job]? {
-        let querySql = "SELECT * FROM job WHERE active == 0 AND failed == '' ORDER BY priority DESC,datetime(created);"
+    
+    func executeAndReturnJobs(querySql: String) -> [Job]? {
         guard let queryStatement = try? prepareStatement(sql: querySql) else {
             return nil
         }
@@ -163,6 +163,16 @@ extension SQLiteDatabase {
         }
         
         return jobs
+    }
+    
+    func getJobs() -> [Job]? {
+        let querySql = "SELECT * FROM job WHERE active == 0 AND failed == '' ORDER BY priority DESC,datetime(created);"
+        return executeAndReturnJobs(querySql: querySql)
+    }
+    
+    func getActiveButTimedOutJobs() -> [Job]? {
+        let querySql = "SELECT * FROM job WHERE active == 1 AND failed == '' AND timeout != 0 AND datetime(created, ('+' || (timeout/1000) || ' seconds')) < datetime('now');"
+        return executeAndReturnJobs(querySql: querySql)
     }
     
     func delete(job: Job) throws{

--- a/ios/JobQueue.m
+++ b/ios/JobQueue.m
@@ -9,4 +9,5 @@ RCT_EXTERN_METHOD(removeJobsByWorkerName:(NSString *)workerName)
 RCT_EXTERN_METHOD(getNextJob:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getJobsForWorker:(NSString *)name count:(NSInteger) count resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getJobs:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getActiveButTimedOutJobs:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 @end

--- a/ios/JobQueue.swift
+++ b/ios/JobQueue.swift
@@ -102,21 +102,38 @@ public class JobQueue:NSObject{
         }
     }
     
+    func getJobsAsDicArray(resolver: () -> [Job]?) -> [[String: Any]] {
+        if let jobs =  resolver(){
+            var jobsAsDictionaryArray=[[String:Any]]()
+            for job in jobs{
+                jobsAsDictionaryArray.append(job.toDictionary())
+            }
+            return jobsAsDictionaryArray
+        }
+        
+        return [[String:Any]]()
+    }
+    
     @objc
     public func getJobs(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock){
-        if(db != nil){
-            if let jobs =  db?.getJobs(){
-                var jobsAsDictionaryArray=[[String:Any]]()
-                for job in jobs{
-                    jobsAsDictionaryArray.append(job.toDictionary())
-                }
-                resolve(jobsAsDictionaryArray)
-            }else{
-                resolve([[String:Any]]())
-            }
-            
+        if(db != nil) {
+            let jobs = getJobsAsDicArray(resolver: db!.getJobs)
+            resolve(jobs);
+        } else {
+            reject(nil, "Database was not initialized", nil)
         }
     }
+    
+    @objc
+    public func getActiveButTimedOutJobs(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock){
+        if(db != nil) {
+            let jobs = getJobsAsDicArray(resolver: db!.getActiveButTimedOutJobs)
+            resolve(jobs);
+        } else {
+            reject(nil, "Database was not initialized", nil)
+        }
+    }
+
     @objc static func requiresMainQueueSetup() -> Bool {
         return false
     }

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -93,6 +93,7 @@ export class Worker<P extends object> {
                 reject(new Error(`Job ${job.id} timed out`));
             }, timeout);
         });
+        // TODO: race doesn't cancel the executer
         await Promise.race([timeoutPromise, this.executer(job.payload)]);
     }
 }

--- a/src/models/JobStore.ts
+++ b/src/models/JobStore.ts
@@ -7,6 +7,7 @@ export interface JobStore {
     addJob(job: RawJob): Promise<void>;
     getJobs(): Promise<RawJob[]>;
     getNextJob(): Promise<RawJob>;
+    getActiveButTimedOutJobs(): Promise<RawJob[]>;
     getJobsForWorker(name: string, count: number): Promise<RawJob[]>;
     updateJob(job: RawJob): void;
     removeJob(job: RawJob): void;

--- a/src/utils/JobQueueMock.ts
+++ b/src/utils/JobQueueMock.ts
@@ -12,6 +12,9 @@ export class JobStoreMock implements JobStore {
     getJobs(): Promise<RawJob[]> {
         return new Promise((resolve) => resolve(this.jobs));
     }
+    getActiveButTimedOutJobs(): Promise<RawJob[]> {
+        return Promise.resolve([]);
+    }
     getNextJob(): Promise<RawJob> {
         // "SELECT * FROM job WHERE active == 0 AND failed == '' ORDER BY priority,datetime(created) LIMIT 1"
         const filtered = this.jobs.filter((job) => job.active === 0 && job.failed === '');


### PR DESCRIPTION
Following use case:

* You create a job with a timeout,
* During job execution (hasn't finished yet), you close the app
* Upon reopening and starting the queue one might expect, that the previous job gets "continued". However, continuing the job isn't really possible due to RN architecture.

Without the fixes in this PR however, the job would never get restarted and still be marked as active forever in the database. The implementation in this PR mark the jobs that are active but considered timed out as failed, so that when the queue starts the job can be retried.

maybe we should add a note to the docs, that the jobs should be idempotent, like [here](https://github.com/billmalarky/react-native-queue#caveats).

I also updated the UI of the example app. To reproduce the issue:
1. Start the example app
2. Click on the second button (which says that it will create a job with a timeout)
3. Click on "Start queue" and close the app immediately (swiping it away)
4. Reopen the app, and click on "Start queue"
You will see that the queue picks up the job (which failed) and will restart it, and thus increases the counter.

This PR also exposes two other issues:
1. In `Promise.race` the executer promise doesn't get cancelled which can lead to strange results
2. I set the job to have `2` attempts. However, the lib runs the job 3-4 times.
These issues should be fixed in another PR: