### PR TITLE
Removed debug print

### DIFF
--- a/ios/Job.swift
+++ b/ios/Job.swift
@@ -83,8 +83,6 @@ extension SQLiteDatabase {
         guard sqlite3_step(insertStatement) == SQLITE_DONE else {
             throw SQLiteError.Step(message: errorMessage)
         }
-        
-        print("Successfully inserted row.")
     }
     func getJobBy(id: NSString) -> Job? {
         let querySql = "SELECT * FROM job WHERE id = ?;"


### PR DESCRIPTION
Tiny PR to remove a `print()` statement which I assumed was left in by mistake. When queueing thousands of jobs this ended up spamming my logs quite a bit.