### PR TITLE
Add jobId as param to Worker execution

### DIFF
--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -29,14 +29,14 @@ export interface QueueOptions {
  * queue.configure({onQueueFinish:(executedJobs:Job[])=>{
  *      console.log("Queue stopped and executed",executedJobs)
  * }});
- * queue.addWorker(new Worker("testWorker",async(payload)=>{
+ * queue.addWorker(new Worker("testWorker",async(payload, id)=>{
  *      return new Promise((resolve) => {
  *      setTimeout(() => {
- *          console.log(payload.text);
+ *          console.log('Executing jobId', id, 'with:', payload.text);
  *          resolve();
  *      }, payload.delay);});
  * }))
- * queue.addJob("testWorker",{text:"Job example palyoad content text",delay:5000})
+ * queue.addJob("testWorker",{text:"Job example payload content text",delay:5000})
  * ```
  */
 export class Queue {

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -21,7 +21,7 @@ export class Worker<P extends object> {
     public readonly concurrency: number;
 
     private executionCount: number;
-    private executer: (payload: P) => CancellablePromise<any>;
+    private executer: (payload: P, id: string) => CancellablePromise<any>;
 
     private onStart: (job: Job<P>) => void;
     private onSuccess: (job: Job<P>) => void;
@@ -35,7 +35,7 @@ export class Worker<P extends object> {
      * @param executer function to run jobs
      * @param options to configure worker
      */
-    constructor(name: string, executer: (payload: P) => Promise<any>, options: WorkerOptions<P> = {}) {
+    constructor(name: string, executer: (payload: P, id: string) => Promise<any>, options: WorkerOptions<P> = {}) {
         const {
             onStart = (job: Job<P>) => {},
             onSuccess = (job: Job<P>) => {},
@@ -81,7 +81,7 @@ export class Worker<P extends object> {
         if (timeout > 0) {
             return this.executeWithTimeout(job, timeout);
         } else {
-            return this.executer(payload);
+            return this.executer(payload, job.id);
         }
     }
     private executeWithTimeout(job: Job<P>, timeout: number) {
@@ -92,7 +92,7 @@ export class Worker<P extends object> {
                     reject(new Error(`Job ${job.id} timed out`));
                 }, timeout);
             });
-            const executerPromise = this.executer(job.payload);
+            const executerPromise = this.executer(job.payload, job.id);
             if (executerPromise) {
                 cancel = executerPromise[CANCEL];
                 try {


### PR DESCRIPTION
Hello,

I want to propose adding the jobId in the worker execution in addition to the payload. It could be helpful to know what is the jobId running inside the job itself wich will add a lot of value in the execution. In my own case, for example to update parent tasks in parallel processing or notifications about progress.

Thanks!