### PR TITLE
feat: support running in background (paused) state

### DIFF
--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, AppState } from 'react-native';
 
 import { FALSE, Job, RawJob } from './models/Job';
 import { JobStore } from './models/JobStore';
@@ -223,7 +223,11 @@ export class Queue {
         await Promise.all(resetTasks);
     }
     private scheduleQueue() {
-        this.timeoutId = setTimeout(this.runQueue, this.updateInterval);
+        if (AppState.currentState === 'active') {
+            this.timeoutId = setTimeout(this.runQueue, this.updateInterval);
+        } else {
+            this.runQueue();
+        }
     }
     private runQueue = async () => {
         if (!this.isActive) {

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -1,3 +1,4 @@
+import { AppState } from 'react-native';
 import { Job, RawJob } from './models/Job';
 
 export const CANCEL = 'rn_job_queue_cancel';
@@ -78,7 +79,7 @@ export class Worker<P extends object> {
         const job = { ...rawJob, ...{ payload } };
         this.executionCount++;
         this.onStart(job);
-        if (timeout > 0) {
+        if (timeout > 0 && AppState.currentState === 'active') {
             return this.executeWithTimeout(job, timeout);
         } else {
             return this.executer(payload, job.id);


### PR DESCRIPTION
### Context
React Native has a limitation where setTimeout does not run while the app is in the "background" state (paused but not completely closed). This issue affects the task queue, causing tasks to execute only when the app returns to the "active" state.

### Solution
This Pull Request adds a check for the app's state before using setTimeout. If the app is in the "background" state, the function is executed immediately, ensuring the task queue works correctly.