### PR TITLE
Spotless issue 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+         mavenCentral()
     }
 
     dependencies {
@@ -59,7 +59,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
Spotless plugin  not resolve when react-native run-android due to the jCenter repository being sunsetted. To address this issue, I update repository configuration in the Gradle file

[https://github.com/SimonErm/react-native-job-queue/issues/102](url)