### PR TITLE
fix: update dependencies to compile in android react native 0.75.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,6 +65,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    api 'android.arch.persistence.room:runtime:1.1.1'
-    annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
+    implementation "androidx.room:room-runtime:2.5.2"
+    annotationProcessor "androidx.room:room-compiler:2.5.2"
+    implementation "androidx.room:room-ktx:2.5.2"
 }


### PR DESCRIPTION
This PR was added due to when I update my app to react-native version 0.74.5 had some problems with compiling process in android. Also, the solution was taken or inspired by the next issue https://github.com/SimonErm/react-native-job-queue/issues/105 